### PR TITLE
Use POST data for Hover API login

### DIFF
--- a/hover.py
+++ b/hover.py
@@ -178,7 +178,7 @@ class HoverAPI(object):
             else:
                 return False
         HoverAPI.logger.info("login attempt for %s", params["username"])
-        response = requests.post("https://www.hover.com/api/login", params=params, cookies=self.cookies)
+        response = requests.post("https://www.hover.com/api/login", data=params, cookies=self.cookies)
         if not response.ok:
             if raise_on_error:
                 raise HoverException(response)


### PR DESCRIPTION
I had problems getting hover-cli to work. During tracing, I found that the user name and password were tacked on to the POST request in URI style, instead of being sent as POST data. Apparently, Hover no longer accepts that encoding, possibly because it leaks credentials into their web server log file. To be on the safe side I have reset my Hover API password.

This diff tells requests to use POST data; it worked immediately for me.